### PR TITLE
[Benchmark] fix the build bug of wget-1.12

### DIFF
--- a/benchmark/wget/1.12/Dockerfile
+++ b/benchmark/wget/1.12/Dockerfile
@@ -13,5 +13,6 @@ ENV URL=https://ftp.gnu.org/gnu/wget/wget-1.12.tar.gz
 
 RUN wget $URL
 RUN tar -xzvf wget-1.12.tar.gz -C $PROGRAM --strip-components 1
+RUN sed -i 's/AM_INIT_AUTOMAKE(dist-bzip2 dist-lzma 1.9)/AM_INIT_AUTOMAKE(1.9)/' wget/configure.ac
 
 WORKDIR $PROGRAM

--- a/benchmark/wget/1.12/build.sh
+++ b/benchmark/wget/1.12/build.sh
@@ -3,7 +3,7 @@
 ./autogen.sh
 ./configure
 
-MAKE_PARAMS="install -j"
+MAKE_PARAMS="install -j MAKEINFO=true POD2MAN=true"
 SMAKE_I_DIR="sparrow/src/wget"
 
 if [[ $1 == "sparrow" ]]; then


### PR DESCRIPTION
sparrow-maintainer에서 `bin/run.py --docker-smake`했을 때, smake가 실패하는 이슈를 해결했습니다.

1. `wget/configure.ac`은 과거에 작성됐고, docker에서 설치하는 autoconf는 최신 버전이라 호환이 안됨.
문제를 일으키는 `dist-lzma`는 wget을 빌드한 이후에, 무엇으로 압축할 것인지에 대한 설정이므로 실험에 필요하지 않음. => 삭제

2. make가 man파일을 만들 때 사용하는 pod2man, makeinfo에서 에러가 발생함. 이 둘을 모두 /bin/true로 치환하여 에러를 제거함.