### PR TITLE
[Benchmark] fix the build bug of amanda-3.3.1

### DIFF
--- a/benchmark/amanda/3.3.1/build.sh
+++ b/benchmark/amanda/3.3.1/build.sh
@@ -2,9 +2,13 @@
 
 ./configure
 
+MAKE_PARAMS="-j"
+
 if [[ $1 == "sparrow" ]]; then
-  echo "TODO: $1"
-  exit 1
+  $SMAKE_BIN --init
+  make -C gnulib -j && make -C common-src -j && make -C amandad-src -j
+  $SMAKE_BIN -C client-src runtar $MAKE_PARAMS
+  cp sparrow/client-src/runtar.o.i $SMAKE_OUT
 elif [[ $1 == "infer" ]]; then
   make -C gnulib -j && make -C common-src -j && make -C amandad-src -j
   $INFER_BIN capture -- make -C client-src runtar


### PR DESCRIPTION
`amanda-3.3.1`은 여러 바이너리로 구성된 소프트웨어입니다. 그래서 `smake`로 빌드하면 컴파일 가능한 많은 `*.i`가 생성됩니다.
그중 실제로 관심있는 바이너리는 `runtar`로 한정되기 때문에 대상 바이너리만 빌드하도록 `build.sh`를 작성했습니다.

**benchmark/amanda/3.3.1/label.json** 
```json
[{
  "project": "amanda",
  "version": "3.3.1",
  "source": {
    "file": "client-src/runtar.c",
    "line": 42,
    "code": "https://github.com/prosyslab-warehouse/amanda-3.3.1/blob/master/client-src/runtar.c#L42"
  },
  "sink": {
    "file": "client-src/runtar.c",
    "line": 159,
    "code": "https://github.com/prosyslab-warehouse/amanda-3.3.1/blob/master/client-src/runtar.c#L159"
  },
  "type": "command-injection",
  "CVE": "CVE-2016-10729",
  "report": "https://cve.circl.lu/cve/cve-2016-10729",
  "patch": null
}]
```