### PR TITLE
[Benchmark] schismtracker: add patch to replace 0[ptr] with *ptr

### DIFF
--- a/benchmark/schismtracker/20190722/03a.page_help.o.i.diff
+++ b/benchmark/schismtracker/20190722/03a.page_help.o.i.diff
@@ -1,0 +1,37 @@
+--- ../bug-bench/smake-out/schismtracker/20190722/03a.page_help.o.i	2021-09-27 15:25:59.000000000 +0900
++++ ./schims-issue.i	2021-12-16 14:21:59.228497081 +0900
+@@ -20249,7 +20249,7 @@
+   switch (**ptr) {
+   default:
+    lp = strcspn(*ptr+1, "\015\012");
+-   if ((0[*ptr] == LTYPE_BIOS || 0[*ptr] == LTYPE_SCHISM_BIOS)) {
++   if ((**ptr == LTYPE_BIOS || **ptr == LTYPE_SCHISM_BIOS)) {
+     draw_text_bios_len(*ptr + 1, lp, 2, pos, 6, 0);
+    } else {
+     draw_text_len(*ptr + 1, lp, 2, pos, **ptr == LTYPE_DISABLED ? 7 : 6, 0);
+@@ -20383,10 +20383,10 @@
+   ptr = help_text[status.current_help_index];
+   while (local_lines--) {
+    if (status.flags & CLASSIC_MODE) {
+-    if (!(0[ptr] == LTYPE_SCHISM || 0[ptr] == LTYPE_SCHISM_BIOS))
++    if (!(*ptr == LTYPE_SCHISM || *ptr == LTYPE_SCHISM_BIOS))
+      lines[cur_line++] = ptr;
+    } else {
+-    if (!(0[ptr] == LTYPE_CLASSIC))
++    if (!(*ptr == LTYPE_CLASSIC))
+      lines[cur_line++] = ptr;
+    }
+    ptr = strpbrk(ptr, "\015\012");
+@@ -20404,10 +20404,10 @@
+  ptr = help_text[HELP_GLOBAL];
+  while (global_lines--) {
+   if (status.flags & CLASSIC_MODE) {
+-   if (!(0[ptr] == LTYPE_SCHISM || 0[ptr] == LTYPE_SCHISM_BIOS))
++   if (!(*ptr == LTYPE_SCHISM || *ptr == LTYPE_SCHISM_BIOS))
+     lines[cur_line++] = ptr;
+   } else {
+-   if (!(0[ptr] == LTYPE_CLASSIC))
++   if (!(*ptr == LTYPE_CLASSIC))
+     lines[cur_line++] = ptr;
+   }
+   ptr = strpbrk(ptr, "\015\012");

--- a/benchmark/schismtracker/20190722/Dockerfile
+++ b/benchmark/schismtracker/20190722/Dockerfile
@@ -1,15 +1,16 @@
 FROM prosyslab/bug-bench-base
 
 RUN apt-get -y update
-RUN apt-get -y install wget autoconf libsdl1.2-dev
+RUN apt-get -y install autoconf libsdl1.2-dev
 
-COPY build.sh $SRC
 ENV PROGRAM=schismtracker
-
 ENV URL=https://github.com/prosyslab-warehouse/schismtracker-20190722.git
 ENV GIT_REPO_NAME=schismtracker-20190722
 
 RUN git clone $URL
 RUN mv $GIT_REPO_NAME $PROGRAM
+
+COPY build.sh $SRC
+COPY 03a.page_help.o.i.diff $SRC
 
 WORKDIR $PROGRAM

--- a/benchmark/schismtracker/20190722/build.sh
+++ b/benchmark/schismtracker/20190722/build.sh
@@ -6,6 +6,7 @@ autoreconf -i
 if [[ $1 == "sparrow" ]]; then
   $SMAKE_BIN --init
   $SMAKE_BIN -j
+  patch sparrow/schismtracker/03a.page_help.o.i ../03a.page_help.o.i.diff
   cp sparrow/schismtracker/*.i $SMAKE_OUT
 elif [[ $1 == "infer" ]]; then
   $INFER_BIN capture -- make


### PR DESCRIPTION
`LINE_BIOS`매크로로 인해 

```c
#define LINE_BIOS(p) (0[p] == LTYPE_BIOS || 0[p] == LTYPE_SCHISM_BIOS)
...
if (LINE_BIOS(*ptr)) {
	draw_text_bios_len(*ptr + 1, lp, 2, pos, 6, 0);
} else {
	draw_text_len(*ptr + 1, lp, 2, pos, **ptr == LTYPE_DISABLED ? 7 : 6, 0);
}
```

위 코드가
```c
if (0[*ptr] == LTYPE_BIOS || 0[*ptr] == LTYPE_SCHISM_BIOS) {
	draw_text_bios_len(*ptr + 1, lp, 2, pos, 6, 0);
} else {
	draw_text_len(*ptr + 1, lp, 2, pos, **ptr == LTYPE_DISABLED ? 7 : 6, 0);
}
```
로 전처리됨.

sparrow의 clang-frontend에서 0은 integer이기 때문에 포인터로 참조가 안되고 버그가 발생함.
워낙 이상한 경우라서 원본 코드를 일부 수정하여 버그를 고침.

`0[ptr] == *(0+ptr) == *ptr` 임을 이용하여 패치를 생성했고, smake-out을 만들 때 자동으로 적용되게 함.