### PR TITLE
[Bin] fix add-repository script.

### DIFF
--- a/bin/add-repo-to-remote.sh
+++ b/bin/add-repo-to-remote.sh
@@ -20,7 +20,7 @@ fi
 mkdir -p /tmp/$REPO_PATH
 pushd /tmp/$REPO_PATH
 
-gh repo create $1 --public -y
+gh repo create $1 --public -c
 wget $2
 tar $TAR_OPTION $FILE_NAME -C $REPO_NAME --strip-components=1
 


### PR DESCRIPTION
bin/add-repo-to-remote.sh 안에서 gh을 이용해 레포지토리를 만들 때 -y옵션을 주어 레포지토리 클론을 같이 합니다. 허나 gh 최신 버전에서 더 이상 -y로 클론이 되지 않아 -c로 수정하였습니다.