### PR TITLE
[benchmark] jasper: link library files into ll file, smake with clang

### DIFF
--- a/benchmark/jasper/1.900.12/build.sh
+++ b/benchmark/jasper/1.900.12/build.sh
@@ -10,7 +10,9 @@ if [[ $1 == "sparrow" ]]; then
   ./configure
   $SMAKE_BIN --init
   $SMAKE_BIN $MAKE_PARAMS
-  mv sparrow/src/appl/*.i $SMAKE_OUT
+  for f in $(find /src/jasper/sparrow/src -name "*.i" -not -path '*/\.*'); do
+    mv $f $SMAKE_OUT/$(basename $f)
+  done
 elif [[ $1 == "infer" ]]; then
   autoreconf -i
   ./configure
@@ -21,15 +23,26 @@ elif [[ $1 == "haechi" ]]; then
   export CFLAGS="-fno-discard-value-names -O0 -Xclang -disable-O0-optnone -g"
   autoreconf -i
   ./configure
-  
+
   $SMAKE_BIN --init
   $SMAKE_BIN $MAKE_PARAMS
-  mv sparrow/src/appl/*.i $SMAKE_OUT
+  for f in $(find /src/jasper/sparrow/src -name "*.i" -not -path '*/\.*'); do
+    mv $f $SMAKE_OUT/$(basename $f)
+  done
 
   EXT_TARGET=src/appl/jasper.o
   $GET_BC_BIN $EXT_TARGET &&
-  llvm-dis -o $EXT_TARGET.ll $EXT_TARGET.bc &&
-  opt -mem2reg -S -o $HAECHI_OUT/$(basename $EXT_TARGET).ll $EXT_TARGET.ll
+    llvm-dis -o $EXT_TARGET.ll $EXT_TARGET.bc &&
+    opt -mem2reg -S -o $EXT_TARGET.ll $EXT_TARGET.ll
+
+  ## link other sources in lib/ to a single file
+  for f in $(find src/libjasper -type f -not -path '*/\.*'); do
+    $GET_BC_BIN $f &&
+      llvm-dis -o $f.ll $f.bc &&
+      opt -mem2reg -S -o src/$(basename $f).ll $f.ll
+  done
+  llvm-link-13 -S src/*.ll $EXT_TARGET.ll -o $HAECHI_OUT/jasper-1.900.12.ll
+
 else
   make -j
 fi

--- a/benchmark/jasper/1.900.21/build.sh
+++ b/benchmark/jasper/1.900.21/build.sh
@@ -10,7 +10,9 @@ if [[ $1 == "sparrow" ]]; then
   ./configure
   $SMAKE_BIN --init
   $SMAKE_BIN $MAKE_PARAMS
-  mv sparrow/src/appl/*.i $SMAKE_OUT
+  for f in $(find /src/jasper/sparrow/src -name "*.i" -not -path '*/\.*'); do
+    mv $f $SMAKE_OUT/$(basename $f)
+  done
 elif [[ $1 == "infer" ]]; then
   autoreconf -i
   ./configure
@@ -21,15 +23,26 @@ elif [[ $1 == "haechi" ]]; then
   export CFLAGS="-fno-discard-value-names -O0 -Xclang -disable-O0-optnone -g"
   autoreconf -i
   ./configure
-  
+
   $SMAKE_BIN --init
   $SMAKE_BIN $MAKE_PARAMS
-  mv sparrow/src/appl/*.i $SMAKE_OUT
+  for f in $(find /src/jasper/sparrow/src -name "*.i" -not -path '*/\.*'); do
+    mv $f $SMAKE_OUT/$(basename $f)
+  done
 
   EXT_TARGET=src/appl/jasper.o
   $GET_BC_BIN $EXT_TARGET &&
-  llvm-dis -o $EXT_TARGET.ll $EXT_TARGET.bc &&
-  opt -mem2reg -S -o $HAECHI_OUT/$(basename $EXT_TARGET).ll $EXT_TARGET.ll
+    llvm-dis -o $EXT_TARGET.ll $EXT_TARGET.bc &&
+    opt -mem2reg -S -o $EXT_TARGET.ll $EXT_TARGET.ll
+
+  ## link other sources in lib/ to a single file
+  for f in $(find src/libjasper -type f -not -path '*/\.*'); do
+    $GET_BC_BIN $f &&
+      llvm-dis -o $f.ll $f.bc &&
+      opt -mem2reg -S -o src/$(basename $f).ll $f.ll
+  done
+  llvm-link-13 -S src/*.ll $EXT_TARGET.ll -o $HAECHI_OUT/jasper-1.900.21.ll
+
 else
   make -j
 fi

--- a/benchmark/jasper/1.900.3/build.sh
+++ b/benchmark/jasper/1.900.3/build.sh
@@ -7,7 +7,9 @@ if [[ $1 == "sparrow" ]]; then
   ./configure
   $SMAKE_BIN --init
   $SMAKE_BIN $MAKE_PARAMS
-  mv sparrow/src/appl/*.i $SMAKE_OUT
+  for f in $(find /src/jasper/sparrow/src -name "*.i" -not -path '*/\.*'); do
+    mv $f $SMAKE_OUT/$(basename $f)
+  done
 elif [[ $1 == "infer" ]]; then
   autoreconf -i
   ./configure
@@ -18,15 +20,26 @@ elif [[ $1 == "haechi" ]]; then
   export CFLAGS="-fno-discard-value-names -O0 -Xclang -disable-O0-optnone -g"
   autoreconf -i
   ./configure
-  
+
   $SMAKE_BIN --init
   $SMAKE_BIN $MAKE_PARAMS
-  mv sparrow/src/appl/*.i $SMAKE_OUT
+  for f in $(find /src/jasper/sparrow/src -name "*.i" -not -path '*/\.*'); do
+    mv $f $SMAKE_OUT/$(basename $f)
+  done
 
   EXT_TARGET=src/appl/jasper.o
   $GET_BC_BIN $EXT_TARGET &&
-  llvm-dis -o $EXT_TARGET.ll $EXT_TARGET.bc &&
-  opt -mem2reg -S -o $HAECHI_OUT/$(basename $EXT_TARGET).ll $EXT_TARGET.ll
+    llvm-dis -o $EXT_TARGET.ll $EXT_TARGET.bc &&
+    opt -mem2reg -S -o $EXT_TARGET.ll $EXT_TARGET.ll
+
+  ## link other sources in lib/ to a single file
+  for f in $(find src/libjasper -type f -not -path '*/\.*'); do
+    $GET_BC_BIN $f &&
+      llvm-dis -o $f.ll $f.bc &&
+      opt -mem2reg -S -o src/$(basename $f).ll $f.ll
+  done
+  llvm-link-13 -S src/*.ll $EXT_TARGET.ll -o $HAECHI_OUT/jasper-1.900.3.ll
+
 else
   make -j
 fi


### PR DESCRIPTION
https://github.com/prosyslab/haechi-maintainer/issues/18 의 2번째 항목을 해결합니다.
- jasper의 build.sh를 수정해, 모든 .i파일을 받아오고, 모든 파일을 링킹해 .ll파일을 뽑도록 만들었습니다.
- 커밋 https://github.com/prosyslab/bug-bench/commit/c582200bb58491c17070769b4d03f5e29b576440 을 참고했습니다.