### PR TITLE
[Trace] add trace for xmllint 2017-9047, 2017-9048

### DIFF
--- a/benchmark/xmllint/2.9.4/label.json
+++ b/benchmark/xmllint/2.9.4/label.json
@@ -17,7 +17,28 @@
   "CVE": "CVE-2017-9047",
   "report": "https://www.openwall.com/lists/oss-security/2017/05/15/1",
   "patch": null,
-  "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/bdec2183f34b37ee89ae1d330c6ad2bb4d76605f/valid.c#L1279"
+  "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/bdec2183f34b37ee89ae1d330c6ad2bb4d76605f/valid.c#L1279",
+  "bug-trace": [{
+    "file": "binutils/valid.c",
+    "line": 5441,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L5441",
+    "cmd": "alloc"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 5445,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L5445",
+    "cmd": "call"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1271,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1271",
+    "cmd": "buffer write"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1279,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1279",
+    "cmd": "buffer write"
+  }]
 }, {
   "project": "xmllint",
   "version": "2.9.4",
@@ -27,7 +48,68 @@
   "CVE": "CVE-2017-9048",
   "report": "https://www.openwall.com/lists/oss-security/2017/05/15/1",
   "patch": null,
-  "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/bdec2183f34b37ee89ae1d330c6ad2bb4d76605f/valid.c#L1323"
+  "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/bdec2183f34b37ee89ae1d330c6ad2bb4d76605f/valid.c#L1323",
+  "bug-trace": [{
+    "file": "binutils/valid.c",
+    "line": 5441,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L5441",
+    "cmd": "alloc"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 5445,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L5445",
+    "cmd": "call"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1306,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1306",
+    "cmd": "call"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1271,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1271",
+    "cmd": "buffer write"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1279,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1279",
+    "cmd": "buffer write"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1306,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1306",
+    "cmd": "return"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1319,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1319",
+    "cmd": "call"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1306,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1306",
+    "cmd": "call"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1271,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1271",
+    "cmd": "buffer write"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1279,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1279",
+    "cmd": "buffer write"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1319,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1319",
+    "cmd": "return"
+  }, {
+    "file": "binutils/valid.c",
+    "line": 1323,
+    "code": "https://github.com/prosyslab-warehouse/libxml2-2.9.4/blob/master/valid.c#L1323",
+    "cmd": "buffer write"
+  }]
 }, {
   "project": "xmllint",
   "version": "2.9.4",


### PR DESCRIPTION
xmllint 버그벤치에 대해 trace를 추가했습니다.
빠른 이해를 위해 하단에 간단하게 버그에 대해 설명을 적었습니다.

### CVE-2017-9047
1. `valid.c:5441`
5000 크기만큼 expr 배열을 할당한다.

2. `valid.c:5445`
`xmlSnprintfElementContent` 함수를 호출하며, `expr`과 `cont`를 넘긴다.
`cont`는 `content` 변수로 사용자가 입력으로 넣은 파일의 XML `name`, `prefix` 정보가 저장된다.

3. `valid.c:1267`
```c
if (size - len < xmlStrlen(content->prefix) + 10) {
        strcat(buf, " ...");
        return;
}
```
`content->prefix`에 대해 길이를 검사한다.
`content`는 함수의 세 번째 인자로 넘어온 `cont` 변수다.
`size`는 두 번째 인자로 같이 넘어온 5000이란 고정값이다. (`buf`의 크기)
`len`은 `strlen(buf)`의 결과값이다.

만약 content->prefix의 길이에 10을 더한 값보다 size - len이 더 작다면, 종료한다.
즉, 추가하려는 content->prefix의 길이보다 buf의 남는 공간이 적다면 prefix를 추가하지 않는다.

4. `valid.c:1271`
`strcat(buf, (char *) content->prefix);`
위의 조건을 우회한다면, `strcat` 함수를 통해 `buf`에 `prefix`를 더한다.
`buf`는 위에서 선언한 `expr` 변수다.

5. `valid.c:1274`
```c
if (size - len < xmlStrlen(content->name) + 10) {
    strcat(buf, " ...");
    return;
}
```
위와 동일하게 `content->name`에 대해서 길이를 검사한다.
하지만, `len`의 경우, `prefix` 값을 넣기 전에 평가한 `strlen(buf)` 값이다.
즉, `content->prefix`를 추가한 길이가 아닌, 추가하기 전에 값이 저장되어 있다.
따라서 `buf`의 남은 길이가 `name`보다 짧아도, 남은 공간이 있다고 인식하게 된다.

6. `valid.c:1279`
`strcat(buf, (char *) content->name);`
위에서 잘못된 길이 검사로 인해 `content->name`을 `buf`에 추가한다.
따라서 버퍼 오버플로우가 발생한다.


### CVE-2017-9048
1. `valid.c:5441`
5000 크기만큼 expr 배열을 할당한다.

2. `valid.c:5445`
`xmlSnprintfElementContent` 함수를 호출하며, `expr`과 `cont`를 넘긴다.
`cont`는 `content` 변수로 사용자가 입력으로 넣은 파일의 XML `name`, `prefix` 정보가 저장된다.

3. `valid.c:1306`
`content-type`이 `XML_ELEMENT_CONTENT_OR`인 경우에는, 재귀적으로 `xmlSnprintfElementContent`를 다시 호출한다.

4. `valid.c:1271, 1279`
POC를 분석한 결과, `XML_ELEMENT_CONTENT_OR` 이후에, `XML_ELEMENT_CONTENT_ELEMENT`로 실행되었다.
CVE-2017-9047과 동일하게 `buf`(즉, `expr` 변수)에 `strcat`을 통해 `prefix`와 `name`을 추가한다.

5. `valid.c:1306`
재귀가 종료된 이후, 다시 `valid.c:1306`으로 리턴된다.

6. `valid.c:1319`
이후 `content->c2->type`에 따라 `xmlSnprintfElementContent `함수를 재귀 호출한다.

7. `valid.c:1306`
재귀호출되며, 다시 `valid.c:1306`에서 다시 재귀호출이 된다.
이후, 위와 동일하게 `valid.c:1271`, `valid.c:1279`에서 `prefix`, `name`에 대해 `strcat`이 진행된다.
최종적으로는 `buf`이 가득 찰 때까지(즉, 길이가 5000이 될 때까지) 이를 반복한다.
> label.json에서는 재귀를 2번만 trace하고, 생략했습니다.

8. `valid.c:1323`
이때, `englob`가 참이라면, `strcat(buf, “)”);`을 호출하며 가득 찬 `buf`에 추가로 “)”를 더한다.
L1323을 포함한 L1324~L1336의 경우, `buf`의 길이 검증 없이 `strcat`을 수행하므로 가득 찬 `buf` 변수에 대해 값을 더 입력할 수 있다.
따라서 buffer overflow가 발생한다.
